### PR TITLE
Enhancement - Updating all EWSType_ResponseMessageType to extend the base class

### DIFF
--- a/EWSType/AttachmentInfoResponseMessageType.php
+++ b/EWSType/AttachmentInfoResponseMessageType.php
@@ -8,10 +8,8 @@
  * request.
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType.
  */
-class EWSType_AttachmentInfoResponseMessageType extends EWSType
+class EWSType_AttachmentInfoResponseMessageType extends EWSType_ResponseMessageType
 {
     /**
      * Contains the items or files that are attached to an item in the Exchange

--- a/EWSType/DisconnectPhoneCallResponseMessageType.php
+++ b/EWSType/DisconnectPhoneCallResponseMessageType.php
@@ -7,10 +7,8 @@
  * Defines the status and result of a single DisconnectPhoneCall request.
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType
  */
-class EWSType_DisconnectPhoneCallResponseMessageType extends EWSType
+class EWSType_DisconnectPhoneCallResponseMessageType extends EWSType_ResponseMessageType
 {
     /**
      * Currently unused and reserved for future use.

--- a/EWSType/ExpandDLResponseMessageType.php
+++ b/EWSType/ExpandDLResponseMessageType.php
@@ -7,10 +7,8 @@
  * Represents the status and result of a single ExpandDL operation request.
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType.
  */
-class EWSType_ExpandDLResponseMessageType extends EWSType
+class EWSType_ExpandDLResponseMessageType extends EWSType_ResponseMessageType
 {
     /**
      * Represents the next denominator to use for the next request when doing\

--- a/EWSType/ExportItemsResponseMessageType.php
+++ b/EWSType/ExportItemsResponseMessageType.php
@@ -8,10 +8,8 @@
  * item.
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType.
  */
-class EWSType_ExportItemsResponseMessageType extends EWSType
+class EWSType_ExportItemsResponseMessageType extends EWSType_ResponseMessageType
 {
     /**
      * Contains the contents of an exported item.

--- a/EWSType/FindConversationResponseMessageType.php
+++ b/EWSType/FindConversationResponseMessageType.php
@@ -7,10 +7,8 @@
  * Defines a response to a FindConversation Operation request.
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType.
  */
-class EWSType_FindConversationResponseMessageType extends EWSType
+class EWSType_FindConversationResponseMessageType extends EWSType_ResponseMessageType
 {
     /**
      * Contains an array of conversations.

--- a/EWSType/FindItemResponseMessageType.php
+++ b/EWSType/FindItemResponseMessageType.php
@@ -7,10 +7,8 @@
  * Represents the status and result of a single FindItem operation request.
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType.
  */
-class EWSType_FindItemResponseMessageType extends EWSType
+class EWSType_FindItemResponseMessageType extends EWSType_ResponseMessageType
 {
     /**
      * Currently unused and reserved for future use.

--- a/EWSType/FindMailboxStatisticsByKeywordsResponseMessageType.php
+++ b/EWSType/FindMailboxStatisticsByKeywordsResponseMessageType.php
@@ -8,10 +8,8 @@
  * request.
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType.
  */
-class EWSType_FindMailboxStatisticsByKeywordsResponseMessageType extends EWSType
+class EWSType_FindMailboxStatisticsByKeywordsResponseMessageType extends EWSType_ResponseMessageType
 {
     /**
      * Currently unused and reserved for future use.

--- a/EWSType/FindMessageTrackingReportResponseMessageType.php
+++ b/EWSType/FindMessageTrackingReportResponseMessageType.php
@@ -8,10 +8,8 @@
  * Operation request.
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType.
  */
-class EWSType_FindMessageTrackingReportResponseMessageType extends EWSType
+class EWSType_FindMessageTrackingReportResponseMessageType extends EWSType_ResponseMessageType
 {
     /**
      * Currently unused and reserved for future use.

--- a/EWSType/GetEventsResponseMessageType.php
+++ b/EWSType/GetEventsResponseMessageType.php
@@ -7,10 +7,8 @@
  * Represents the status and result of a single GetEvents operation request.
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType.
  */
-class EWSType_GetEventsResponseMessageType extends EWSType
+class EWSType_GetEventsResponseMessageType extends EWSType_ResponseMessageType
 {
     /**
      * Currently unused and reserved for future use.

--- a/EWSType/GetInboxRulesResponseType.php
+++ b/EWSType/GetInboxRulesResponseType.php
@@ -7,10 +7,8 @@
  * Defines a response to a GetInboxRules operation request.
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType.
  */
-class EWSType_GetInboxRulesResponseType extends EWSType
+class EWSType_GetInboxRulesResponseType extends EWSType_ResponseMessageType
 {
     /**
      * Currently unused and reserved for future use.

--- a/EWSType/GetMessageTrackingReportResponseMessageType.php
+++ b/EWSType/GetMessageTrackingReportResponseMessageType.php
@@ -7,10 +7,8 @@
  * Represents the response for the GetMessageTrackingReport operation.
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType.
  */
-class EWSType_GetMessageTrackingReportResponseMessageType extends EWSType
+class EWSType_GetMessageTrackingReportResponseMessageType extends EWSType_ResponseMessageType
 {
     /**
      * Currently unused and reserved for future use.

--- a/EWSType/GetPhoneCallInformationResponseMessageType.php
+++ b/EWSType/GetPhoneCallInformationResponseMessageType.php
@@ -7,10 +7,8 @@
  * Defines a response to a single GetPhoneCallInformation request.
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType.
  */
-class EWSType_GetPhoneCallInformationResponseMessageType extends EWSType
+class EWSType_GetPhoneCallInformationResponseMessageType extends EWSType_ResponseMessageType
 {
     /**
      * Currently unused and reserved for future use.

--- a/EWSType/GetRoomListsResponseMessageType.php
+++ b/EWSType/GetRoomListsResponseMessageType.php
@@ -7,10 +7,8 @@
  * Represents the response from a GetRoomLists Operation request.
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType
  */
-class EWSType_GetRoomListsResponseMessageType extends EWSType
+class EWSType_GetRoomListsResponseMessageType extends EWSType_ResponseMessageType
 {
     /**
      * Currently unused and reserved for future use.

--- a/EWSType/GetRoomsResponseMessageType.php
+++ b/EWSType/GetRoomsResponseMessageType.php
@@ -7,10 +7,8 @@
  * Represents the response to a GetRooms operation request.
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType
  */
-class EWSType_GetRoomsResponseMessageType extends EWSType
+class EWSType_GetRoomsResponseMessageType extends EWSType_ResponseMessageType
 {
     /**
      * Currently unused and reserved for future use.

--- a/EWSType/GetServiceConfigurationResponseMessageType.php
+++ b/EWSType/GetServiceConfigurationResponseMessageType.php
@@ -7,10 +7,8 @@
  * Defines a response to a GetServiceConfiguration request.
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType.
  */
-class EWSType_GetServiceConfigurationResponseMessageType extends EWSType
+class EWSType_GetServiceConfigurationResponseMessageType extends EWSType_ResponseMessageType
 {
     /**
      * Currently unused and reserved for future use.

--- a/EWSType/GetSharingFolderResponseMessageType.php
+++ b/EWSType/GetSharingFolderResponseMessageType.php
@@ -8,10 +8,8 @@
  * request.
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType
  */
-class EWSType_GetSharingFolderResponseMessageType extends EWSType
+class EWSType_GetSharingFolderResponseMessageType extends EWSType_ResponseMessageType
 {
     /**
      * Currently unused and reserved for future use.

--- a/EWSType/GetSharingMetadataResponseMessageType.php
+++ b/EWSType/GetSharingMetadataResponseMessageType.php
@@ -7,10 +7,8 @@
  * Represents the status and result of a request.
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType.
  */
-class EWSType_GetSharingMetadataResponseMessageType extends EWSType
+class EWSType_GetSharingMetadataResponseMessageType extends EWSType_ResponseMessageType
 {
     /**
      * Currently unused and reserved for future use.

--- a/EWSType/GetStreamingEventsResponseMessageType.php
+++ b/EWSType/GetStreamingEventsResponseMessageType.php
@@ -8,10 +8,8 @@
  * request.
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType.
  */
-class EWSType_GetStreamingEventsResponseMessageType extends EWSType
+class EWSType_GetStreamingEventsResponseMessageType extends EWSType_ResponseMessageType
 {
     /**
      * Provides a text description of the status of a streaming subscription.

--- a/EWSType/GetUserConfigurationResponseMessageType.php
+++ b/EWSType/GetUserConfigurationResponseMessageType.php
@@ -7,10 +7,8 @@
  * Represents a response that returns a user configuration object.
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType.
  */
-class EWSType_GetUserConfigurationResponseMessageType extends EWSType
+class EWSType_GetUserConfigurationResponseMessageType extends EWSType_ResponseMessageType
 {
     /**
      * Currently unused and reserved for future use.

--- a/EWSType/ItemInfoResponseMessageType.php
+++ b/EWSType/ItemInfoResponseMessageType.php
@@ -7,10 +7,8 @@
  * Represents the status and result of a single item operation request.
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType.
  */
-class EWSType_ItemInfoResponseMessageType extends EWSType
+class EWSType_ItemInfoResponseMessageType extends EWSType_ResponseMessageType
 {
     /**
      * Currently unused and reserved for future use.

--- a/EWSType/MailTipsResponseMessageType.php
+++ b/EWSType/MailTipsResponseMessageType.php
@@ -7,10 +7,8 @@
  * Represents mail tips settings.
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType.
  */
-class EWSType_MailTipsResponseMessageType extends EWSType
+class EWSType_MailTipsResponseMessageType extends EWSType_ResponseMessageType
 {
     /**
      * Currently unused and reserved for future use.

--- a/EWSType/PlayOnPhoneResponseMessageType.php
+++ b/EWSType/PlayOnPhoneResponseMessageType.php
@@ -7,10 +7,8 @@
  * Defines the response to a request to play a voice mail over the telephone.
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType.
  */
-class EWSType_PlayOnPhoneResponseMessageType extends EWSType
+class EWSType_PlayOnPhoneResponseMessageType extends EWSType_ResponseMessageType
 {
     /**
      * Currently unused and reserved for future use.

--- a/EWSType/RefreshSharingFolderResponseMessageType.php
+++ b/EWSType/RefreshSharingFolderResponseMessageType.php
@@ -7,10 +7,8 @@
  * Class description...
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType.
  */
-class EWSType_RefreshSharingFolderResponseMessageType extends EWSType
+class EWSType_RefreshSharingFolderResponseMessageType extends EWSType_ResponseMessageType
 {
     /**
      * Currently unused and reserved for future use.

--- a/EWSType/ResolveNamesResponseMessageType.php
+++ b/EWSType/ResolveNamesResponseMessageType.php
@@ -7,10 +7,8 @@
  * Defines the status and result of a ResolveNames operation request.
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType.
  */
-class EWSType_ResolveNamesResponseMessageType extends EWSType
+class EWSType_ResolveNamesResponseMessageType extends EWSType_ResponseMessageType
 {
     /**
      * Currently unused and reserved for future use.

--- a/EWSType/SendNotificationResponseMessageType.php
+++ b/EWSType/SendNotificationResponseMessageType.php
@@ -8,10 +8,8 @@
  * request.
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType.
  */
-class EWSType_SendNotificationResponseMessageType extends EWSType
+class EWSType_SendNotificationResponseMessageType extends EWSType_ResponseMessageType
 {
     /**
      * Currently unused and reserved for future use.

--- a/EWSType/ServiceConfigurationResponseMessageType.php
+++ b/EWSType/ServiceConfigurationResponseMessageType.php
@@ -7,10 +7,8 @@
  * Represents service configuration settings.
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType.
  */
-class EWSType_ServiceConfigurationResponseMessageType extends EWSType
+class EWSType_ServiceConfigurationResponseMessageType extends EWSType_ResponseMessageType
 {
     /**
      * Currently unused and reserved for future use.

--- a/EWSType/SubscribeResponseMessageType.php
+++ b/EWSType/SubscribeResponseMessageType.php
@@ -7,10 +7,8 @@
  * Represents the status and result of a single Subscribe Operation request.
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType.
  */
-class EWSType_SubscribeResponseMessageType extends EWSType
+class EWSType_SubscribeResponseMessageType extends EWSType_ResponseMessageType
 {
     /**
      * Currently unused and reserved for future use.

--- a/EWSType/SyncFolderHierarchyResponseMessageType.php
+++ b/EWSType/SyncFolderHierarchyResponseMessageType.php
@@ -8,10 +8,8 @@
  * request.
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType.
  */
-class EWSType_SyncFolderHierarchyResponseMessageType extends EWSType
+class EWSType_SyncFolderHierarchyResponseMessageType extends EWSType_ResponseMessageType
 {
     /**
      * Contains a sequence array of change types that represent the types of

--- a/EWSType/SyncFolderItemsResponseMessageType.php
+++ b/EWSType/SyncFolderItemsResponseMessageType.php
@@ -8,10 +8,8 @@
  * request.
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType.
  */
-class EWSType_SyncFolderItemsResponseMessageType extends EWSType
+class EWSType_SyncFolderItemsResponseMessageType extends EWSType_ResponseMessageType
 {
     /**
      * Contains a sequence array of change types that represent the types of

--- a/EWSType/UpdateInboxRulesResponseType.php
+++ b/EWSType/UpdateInboxRulesResponseType.php
@@ -7,10 +7,8 @@
  * Defines a response to an UpdateInboxRules request.
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType.
  */
-class EWSType_UpdateInboxRulesResponseType extends EWSType
+class EWSType_UpdateInboxRulesResponseType extends EWSType_ResponseMessageType
 {
     /**
      * Currently unused and reserved for future use.

--- a/EWSType/UploadItemsResponseMessageType.php
+++ b/EWSType/UploadItemsResponseMessageType.php
@@ -7,10 +7,8 @@
  * the status and results of a request to upload a single mailbox item.
  *
  * @package php-ews\Types
- *
- * @todo Extend EWSType_ResponseMessageType.
  */
-class EWSType_UploadItemsResponseMessageType extends EWSType
+class EWSType_UploadItemsResponseMessageType extends EWSType_ResponseMessageType
 {
     /**
      * Currently unused and reserved for future use.


### PR DESCRIPTION
I noticed when attempting to handle `EWSType_ResponseMessageType`s that I wanted to be able to retrieve the `MessageText` of a potentially failed response. This would have been a huge PITA without making things a little more generic.

This PR correctly extends all of the `ResponseMessageType` classes. I'll probably make a PR for the main `php-ews` library for quality of life.
